### PR TITLE
get rid of reference to old JNDI class

### DIFF
--- a/admin/src/main/kotlin/io/nats/bridge/admin/models/bridges/DataModels.kt
+++ b/admin/src/main/kotlin/io/nats/bridge/admin/models/bridges/DataModels.kt
@@ -182,7 +182,7 @@ val defaultDataModel = NatsBridgeConfig(
                                 userName = "app",
                                 password = "passw0rd",
                                 config = mapOf(
-                                        "java.naming.factory.initial" to "io.nats.bridge.ibmmq.IbmMqInitialContextFactory",
+                                        "java.naming.factory.initial" to "io.nats.bridge.integration.ibmmq.IbmMqInitialContextFactory",
                                         "nats.ibm.mq.host" to "tcp://localhost:1414",
                                         "nats.ibm.mq.channel" to "DEV.APP.SVRCONN",
                                         "nats.ibm.mq.queueManager" to "QM1"


### PR DESCRIPTION
get rid of the reference to old JNDI class