### PR TITLE
Prepare for Friday release. 

### DIFF
--- a/admin/.gitignore
+++ b/admin/.gitignore
@@ -10,6 +10,7 @@ build/
 /keys/public_key.pem
 /data
 /admin
-/config
+/config/
 /out
 
+/config/

--- a/admin/sampleConf/nats-bridge-ibm-mq-no-conf.yaml
+++ b/admin/sampleConf/nats-bridge-ibm-mq-no-conf.yaml
@@ -54,3 +54,4 @@ clusters:
       userName: "app"
       password: "passw0rd2"
       jmsDestinationType: "QUEUE"
+      autoConfig: "IBM_MQ"

--- a/admin/src/main/kotlin/io/nats/bridge/admin/integration/IntegrationRequestReplyUtils.kt
+++ b/admin/src/main/kotlin/io/nats/bridge/admin/integration/IntegrationRequestReplyUtils.kt
@@ -115,7 +115,12 @@ class IntegrationRequestReplyUtils {
         val serverBuilder = builder.destinationBusBuilder!!
 
         if (serverBuilder is JMSMessageBusBuilder) {
+            serverBuilder.useIBMMQ() //TODO fix so this works with activemq too
             serverBuilder.asSource()
+        }
+
+        if (builder2.destinationBusBuilder!! is JMSMessageBusBuilder) {
+            (builder2.destinationBusBuilder as JMSMessageBusBuilder).useIBMMQ() //todo fix so this works with activemq
         }
 
         val clientBus = clientBuilder.build()

--- a/admin/src/main/kotlin/io/nats/bridge/admin/runner/support/impl/MessageBridgeLoaderImpl.kt
+++ b/admin/src/main/kotlin/io/nats/bridge/admin/runner/support/impl/MessageBridgeLoaderImpl.kt
@@ -94,7 +94,15 @@ class MessageBridgeLoaderImpl(private val repo: ConfigRepo, private val metricsR
         if (config.userName != null) builder.withUserNameConnection(config.userName)
         if (config.password != null) builder.withPasswordConnection(config.password)
         if (bridge.copyHeaders != null) builder.withCopyHeaders(bridge.copyHeaders)
+
+        if (config.autoConfig == JmsAutoConfig.IBM_MQ) {
+            builder.useIBMMQ()
+        } else if (config.autoConfig == JmsAutoConfig.ACTIVE_MQ) {
+            builder.jndiProperties
+        }
+
         if (config.config.isNotEmpty()) builder.withJndiProperties(config.config)
+
 
         return builder
     }

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -106,6 +106,7 @@ clean_docker_images() {
 
 copy_ibm_test_config() {
   echo "copying sample conf nats-bridge-ibm-mq-demo-conf.yaml to admin conf"
+  touch  admin/config/nats-bridge.bak
   echo "-----back up------" >> admin/config/nats-bridge.bak
   cat admin/config/nats-bridge.yaml >> admin/config/nats-bridge.bak
   cp admin/sampleConf/nats-bridge-ibm-mq-demo-conf.yaml admin/config/nats-bridge.yaml
@@ -123,21 +124,24 @@ docker_deploy_test() {
 
 help () {
   echo "Valid commands:"
-  echo "Use build_ibm_mq_image, bimi to build IBM image"
-  echo "Use build_admin_image, bai, admin to build NATs bridge admin"
-  echo "Use clean_docker_images | clean_docker | ci to clear out docker images"
-  echo "Use build_prometheus_image | bpi to build prometheus which can scrape admin"
-  echo "Use build_bridge_nats_server_image | nats to build prometheus which can scrape admin"
-  echo "Use build_bridge_activemq | activemq to build activemq"
-  echo "Use build_gradle_image to build travis image for testing"
-  echo "Use build_travis_build_image to build travis image for testing"
-  echo "Use localdev to run all images for local development"
-  echo "Use docker_deploy_test to run a version of IBM MQ that has non default values use config sample nats-bridge-ibm-mq-demo-conf.yaml"
+  echo "Docker Builds:"
+  echo "Use 'build_ibm_mq_image', bimi to build IBM image"
+  echo "Use 'build_admin_image', bai, admin to build NATs bridge admin"
+  echo "Use 'clean_docker_images' | clean_docker | ci to clear out docker images"
+  echo "Use 'build_prometheus_image' | bpi to build prometheus which can scrape admin"
+  echo "Use 'build_bridge_nats_server_image' | nats to build prometheus which can scrape admin"
+  echo "Use 'build_bridge_activemq' | activemq to build activemq"
+  echo "Use 'build_gradle_image' to build travis image for testing"
+  echo "Use 'build_travis_build_image' to build travis image for testing"
+  echo "Docker Compose:"
+  echo "Use 'localdev' to run all images for local development"
+  echo "Use 'docker_deploy_test' to run a version of IBM MQ that has non default values use config sample nats-bridge-ibm-mq-demo-conf.yaml"
+  echo "Gradle Builds Compose:"
   echo "Use build_install_dir to create install dir"
   echo "Use build_admin_image_local or bai_local to build a admin image that does not depend on a release"
-
-  echo "Use prepare_ibm_mq_test to prepare for IBM MQ example config in yaml"
-  echo "Use prepare_ibm_mq_env_test to prepare for IBM MQ config with env vars only"
+  echo "QA integration tests:"
+  echo "Use 'prepare_ibm_mq_test' to prepare for IBM MQ example config in yaml"
+  echo "Use 'prepare_ibm_mq_env_test' to prepare for IBM MQ config with env vars only"
 }
 
 
@@ -216,6 +220,13 @@ build_travis_build_image)
 localdev)
         bin/docker-deploy-local-dev.sh
         ;;
+
+stop-localdev)
+  cd cicd
+  docker-compose  stop
+  cd ..
+  ;;
+
 
 docker_deploy_test)
       docker_deploy_test


### PR DESCRIPTION
* #90 openssl example work
* #107 test on linux using Java 8 
* #114 Add auto-config for IBM MQ and Active MQ  
* #96 Example using IBM env vars from bridge admin 

#### Added ability to use env vars from bridge admin
#### sample-confg/nats-bridge-ibm-mq-no-conf.yaml
```yaml
bridges:
- name: "natsToIBMMq"
  bridgeType: "REQUEST_REPLY"
  source:
    name: "nats"
    busType: "NATS"
    subject: "b-subject"
    clusterName: "natsCluster"
  destination:
    name: "ibmMQ"
    busType: "JMS"
    subject: "MY.QUEUE.1"
    clusterName: "ibmMqCluster"
  copyHeaders: false
  workers: 5
  tasks : 2

clusters:
  jmsCluster:
    name: "jmsCluster"
    properties: !<jms>
      config:
        java.naming.factory.initial: "org.apache.activemq.artemis.jndi.ActiveMQInitialContextFactory"
        connectionFactory.ConnectionFactory: "tcp://localhost:61616"
        queue.queue/testQueue: "queue.queue/testQueue=testQueue"
      userName: "cloudurable"
      password: "cloudurable"
      jmsDestinationType: "QUEUE"
  natsCluster:
    name: "natsCluster"
    properties: !<nats>
      host: "localhost"
      port: 4222
      servers: []
      config:
        io.nats.client.reconnect.wait: 3000
        io.nats.client.reconnect.max: 10
        io.nats.client.timeout: 4000
  ibmMqCluster:
    name: "ibmMqCluster"
    properties: !<jms>
      config:
        {}
      userName: "app"
      password: "passw0rd2"
      jmsDestinationType: "QUEUE"
      autoConfig: "IBM_MQ"
```

To use this test run with ` bin/build.sh docker_deploy_test` from the root of the project which will launch docker deploy for the IBM docker image that is different than the defaults. 

```
 $ pwd
/Users/richardhightower/synadia/nats-bridge
(⎈ |N/A:N/A)richardhightower@Richards-MacBook-Pro nats-bridge % 
 $ bin/build.sh help
Valid commands:
Docker Builds:
Use 'build_ibm_mq_image', bimi to build IBM image
Use 'build_admin_image', bai, admin to build NATs bridge admin
Use 'clean_docker_images' | clean_docker | ci to clear out docker images
Use 'build_prometheus_image' | bpi to build prometheus which can scrape admin
Use 'build_bridge_nats_server_image' | nats to build prometheus which can scrape admin
Use 'build_bridge_activemq' | activemq to build activemq
Use 'build_gradle_image' to build travis image for testing
Use 'build_travis_build_image' to build travis image for testing
Docker Compose:
Use 'localdev' to run all images for local development
Use 'docker_deploy_test' to run a version of IBM MQ that has non default values use config sample nats-bridge-ibm-mq-demo-conf.yaml
Gradle Builds Compose:
Use build_install_dir to create install dir
Use build_admin_image_local or bai_local to build a admin image that does not depend on a release
QA integration tests:
Use 'prepare_ibm_mq_test' to prepare for IBM MQ example config in yaml
Use 'prepare_ibm_mq_env_test' to prepare for IBM MQ config with env vars only
```