### PR TITLE
tweak useIBM to not clear properties

### DIFF
--- a/admin/src/main/kotlin/io/nats/bridge/admin/integration/IntegrationRequestReplyUtils.kt
+++ b/admin/src/main/kotlin/io/nats/bridge/admin/integration/IntegrationRequestReplyUtils.kt
@@ -118,7 +118,7 @@ class IntegrationRequestReplyUtils {
         }
 
         if (builder2.destinationBusBuilder!! is JMSMessageBusBuilder) {
-            (builder2.destinationBusBuilder as JMSMessageBusBuilder).useIBMMQ() //todo fix so this works with activemq
+            (builder2.destinationBusBuilder as JMSMessageBusBuilder).useIBMMQ() //todo fix so this works with activemq also
         }
 
         val clientBus = clientBuilder.build()

--- a/admin/src/main/kotlin/io/nats/bridge/admin/runner/support/impl/MessageBridgeLoaderImpl.kt
+++ b/admin/src/main/kotlin/io/nats/bridge/admin/runner/support/impl/MessageBridgeLoaderImpl.kt
@@ -138,13 +138,15 @@ class MessageBridgeLoaderImpl(private val repo: ConfigRepo, private val metricsR
         if (config.password != null) builder.withPasswordConnection(config.password)
         if (bridge.copyHeaders != null) builder.withCopyHeaders(bridge.copyHeaders)
 
+        if (config.config.isNotEmpty()) builder.withJndiProperties(config.config)
+
         if (config.autoConfig == JmsAutoConfig.IBM_MQ) {
             builder.useIBMMQ()
         } else if (config.autoConfig == JmsAutoConfig.ACTIVE_MQ) {
             builder.jndiProperties
         }
 
-        if (config.config.isNotEmpty()) builder.withJndiProperties(config.config)
+
 
 
         return builder


### PR DESCRIPTION
tweak useIBM to not clear properties

_____

# 0.19.0-beta15 NATS JMS/MQ Bridge

#### TAG: 0.19.0-beta15

## Issues


* #197 #205 Enable IBM MQ retested with multiple IBM MQ servers and it fails over in middle of integration when IBM MQ server is killed. 
* #172 #210 Alias not working with tlsverify root cert. Fixed. 


## Failover is working for IBM MQ 

We were able to set up multiple IBM MQ servers and verify failover to second server 
in middle of integration test when we killed the first server. 
We tested this by setting up three servers. Then running integration tests. 
It failed over to 2nd server and when we killed second server, it failed over to 3rd. 
We also killed an IBM MQ server in the middle and the integration test continues to run and completes
without message loss. 

We had to ensure that we were not setting the host so that the IBM MQ client would 
use the connection list for failover. 


## TLS Verify with Keystore Alias 

We were able to set this up and test this out. 

## Notes on TLS TLS verify set up (creating root CA)
## TLS Keystore Alias issue

To fix this issue, we had to reproduce the issue and to that we had to set up NATS to verify TLS.
To do that we had to create a root CA and install it. Then use that from Java SSL support.  

To fix this issue we followed these:

## Removed the folder certs/keyalias/ with all content used in the previous version.

```sh
~/bridge2
cd certs/
rm -rf keyalias/
```

## Created a new folder called alias inside certs/

```sh
pwd
Output:
~/bridge2/certs
mkdir alias
```
Now create the **certificates**, **keystore** and **truststore**

### Certificates

Enter in the alias folder
```sh
cd alias

pwd
Output:
~/bridge2/certs/alias
```

## **Server Certificate**
```sh
mkcert -cert-file server-cert.pem -key-file server-key.pem localhost ::1

Output:
Using the local CA at "~/Library/Application Support/mkcert" ✨

Created a new certificate valid for the following names 📜
 - "localhost"
 - "::1"

The certificate is at "server-cert.pem" and the key at "server-key.pem" ✅
```

## **Clients Certificates**

Client Certificate
```sh
mkcert -client -cert-file client-cert.pem -key-file client-key.pem localhost ::1

Output:
Using the local CA at "~/Library/Application Support/mkcert" ✨

Created a new certificate valid for the following names 📜
 - "localhost"
 - "::1"

The certificate is at "client-cert.pem" and the key at "client-key.pem" ✅
```

## Create Sample Cloudurable Certificate

```sh
mkcert -client -cert-file cloudurable-cert.pem -key-file cloudurable-key.pem localhost ::1

Output:
Using the local CA at "~/Library/Application Support/mkcert" ✨

Created a new certificate valid for the following names 📜
 - "localhost"
 - "::1"

The certificate is at "cloudurable-cert.pem" and the key at "cloudurable-key.pem" ✅
```

## Create sample Mammatus Certificate
```sh
mkcert -client -cert-file mamatus-cert.pem -key-file mamatus-key.pem localhost ::1

Outuput:
Using the local CA at "~/Library/Application Support/mkcert" ✨

Created a new certificate valid for the following names 📜
 - "localhost"
 - "::1"

The certificate is at "mamatus-cert.pem" and the key at "mamatus-key.pem" ✅
```

Now we have 4 certificates and 4 certificates key, to check it list the folder content
```sh
ls

Output:
client-cert.pem		cloudurable-key.pem	server-cert.pem
client-key.pem		mamatus-cert.pem	server-key.pem
cloudurable-cert.pem	mamatus-key.pem
```

The tag -client for the client certificate, that tag told to the truststore that this certificate will be used by a client.

This is needed to configure the tlsverify option on the Nats server.
When the flag tlsverify is set to true we need to configure the rootCA on the server.

To obtain the path for the root CA type:

## Get path for root CA

```sh
mkcert -CAROOT

Output:
~/Library/Application Support/mkcert


cp ~/Library/Application\ Support/mkcert/rootCA.pem rootCA.pem

ls

client-cert.pem		cloudurable-key.pem	rootCA.pem
client-key.pem		mamatus-cert.pem	server-cert.pem
cloudurable-cert.pem	mamatus-key.pem		server-key.pem

openssl pkcs12 -export -out client.p12 -inkey client-key.pem -in client-cert.pem -password pass:password -name "client-cert"

openssl pkcs12 -export -out cloudurable.p12 -inkey cloudurable-key.pem -in cloudurable-cert.pem -password pass:password -name "cloudurable-cert" 

openssl pkcs12 -export -out mamatus.p12 -inkey mamatus-key.pem -in mamatus-cert.pem -password pass:password -name "mamatus-cert"

-name, config the alias

client-cert.pem		cloudurable-key.pem	mamatus.p12
client-key.pem		cloudurable.p12		rootCA.pem
client.p12		mamatus-cert.pem	server-cert.pem
cloudurable-cert.pem	mamatus-key.pem		server-key.pem

keytool -importkeystore -srcstoretype PKCS12 -srckeystore client.p12 -srcstorepass password -destkeystore keystore.jks -deststorepass password -alias client-cert

keytool -keystore keystore.jks -storetype jks -importcert -file cloudurable-cert.pem -alias cloudurable-cert

keytool -importkeystore -srcstoretype PKCS12 -srckeystore cloudurable.p12 -srcstorepass password -destkeystore keystore.jks -deststorepass password -alias cloudurable-cert

keytool -importkeystore -srcstoretype PKCS12 -srckeystore mamatus.p12 -srcstorepass password -destkeystore keystore.jks -deststorepass password -alias mamatus-cert

client-cert.pem		cloudurable.p12		rootCA.pem
client-key.pem		keystore.jks		server-cert.pem
client.p12		mamatus-cert.pem	server-key.pem
cloudurable-cert.pem	mamatus-key.pem
cloudurable-key.pem	mamatus.p12

keytool -importcert -trustcacerts -file rootCA.pem -storepass cloudurable2 -noprompt -keystore truststore.jks

client-cert.pem		cloudurable.p12		rootCA.pem
client-key.pem		keystore.jks		server-cert.pem
client.p12		mamatus-cert.pem	server-key.pem
cloudurable-cert.pem	mamatus-key.pem		truststore.jks
cloudurable-key.pem	mamatus.p12

```


## Now run NATS server with tlsverify.


```sh

nats-server -DV --tls --tlscert=~/job/nats-jms-mq-bridge2/bridge2/certs/alias/server-cert.pem /
--tlskey=~/job/nats-jms-mq-bridge2/bridge2/certs/alias/server-key.pem /
--tlscacert=~/job/nats-jms-mq-bridge2/bridge2/certs/alias/rootCA.pem --tlsverify=true

```